### PR TITLE
Custom rendering of errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/umd/*
 dist/package-lock.json
 dist/README.md
 node_modules
+.idea

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -25,6 +25,7 @@ import SelectionMode from './SelectionMode';
 import SpecialZoomLevel from './SpecialZoomLevel';
 import ThemeProvider from './theme/ThemeProvider';
 import PdfJs from './vendors/PdfJs';
+import RenderError from "./types/RenderError";
 
 interface RenderViewerProps {
     viewer: React.ReactElement;
@@ -55,6 +56,8 @@ interface ViewerProps {
     prefixClass?: string;
     render?: RenderViewerType;
     renderPage?: RenderPage;
+    // Support for custom error rendering
+    renderError?: RenderError;
     // The text selection mode
     selectionMode?: SelectionMode;
     onDocumentLoad?(doc: PdfJs.PdfDocument): void;
@@ -71,6 +74,7 @@ const Viewer: React.FC<ViewerProps> = ({
     prefixClass,
     render,
     renderPage,
+    renderError,
     selectionMode = SelectionMode.Text,
     onDocumentLoad = () => {/**/},
     onZoom = () => {/**/},
@@ -139,6 +143,7 @@ const Viewer: React.FC<ViewerProps> = ({
                 <DocumentLoader
                     file={file.data}
                     render={renderDoc(defaultRenderer)}
+                    renderError={renderError}
                 />
             </LocalizationProvider>
         </ThemeProvider>

--- a/src/loader/DocumentLoader.tsx
+++ b/src/loader/DocumentLoader.tsx
@@ -20,13 +20,15 @@ import LoadingState from './LoadingState';
 import LoadingStatus, { VerifyPassword } from './LoadingStatus';
 import WrongPassword from './WrongPassword';
 import WrongPasswordState from './WrongPasswordState';
+import RenderError from "../types/RenderError";
 
 interface DocumentLoaderProps {
     file: PdfJs.FileData;
     render(doc: PdfJs.PdfDocument): React.ReactElement;
+    renderError?: RenderError;
 }
 
-const DocumentLoader: React.FC<DocumentLoaderProps> = ({ file, render }) => {
+const DocumentLoader: React.FC<DocumentLoaderProps> = ({ file, render, renderError }) => {
     const theme = React.useContext(ThemeContent);
     const [status, setStatus] = React.useState<LoadingStatus>(new LoadingState(0));
 
@@ -70,12 +72,18 @@ const DocumentLoader: React.FC<DocumentLoaderProps> = ({ file, render }) => {
             return <WrongPassword verifyPasswordFn={(status as WrongPasswordState).verifyPasswordFn} />;
         case (status instanceof CompletedState):
             return render((status as CompletedState).doc);
-        case (status instanceof FailureState):
-            return (
-                <div className={`${theme.prefixClass}-doc-error`}>
-                    {(status as FailureState).error}
-                </div>
-            );
+        case (status instanceof FailureState): {
+            const message = (status as FailureState).error;
+            if (renderError) {
+                return renderError(message);
+            } else {
+                return (
+                    <div className={`${theme.prefixClass}-doc-error`}>
+                        {message}
+                    </div>
+                );
+            }
+        }
         case (status instanceof LoadingState):
         default:
             return (

--- a/src/types/RenderError.ts
+++ b/src/types/RenderError.ts
@@ -1,0 +1,5 @@
+import React from "react";
+
+type RenderError = (message: string) => React.ReactElement;
+
+export default RenderError;


### PR DESCRIPTION
Added support for custom rendering of erros when document fails to load.

This would allow the customer to use their own layouts when there is an error.

Ticket: https://github.com/phuoc-ng/react-pdf-viewer/issues/65

Would be great after your review @phuoc-ng if we could push a new version v.1.4.1.

Thank you! :) 