### PR TITLE
Support multiple keyword regex

### DIFF
--- a/packages/search/src/Tracker.tsx
+++ b/packages/search/src/Tracker.tsx
@@ -54,7 +54,7 @@ const Tracker: React.FC<{
 
         const match = text.match(keywordRegexp) //doesn't support 'g' flag
         const firstChild = span.firstChild;
-        if (match || !firstChild) {
+        if (!match || !firstChild) {
             return;
         }
         const startOffset = match.index;

--- a/packages/search/src/Tracker.tsx
+++ b/packages/search/src/Tracker.tsx
@@ -52,12 +52,13 @@ const Tracker: React.FC<{
             return;
         }
 
-        const startOffset = text.search(keywordRegexp);
+        const match = text.match(keywordRegexp) //doesn't support 'g' flag
         const firstChild = span.firstChild;
-        if (startOffset === -1 || !firstChild) {
+        if (match || !firstChild) {
             return;
         }
-        const endOffset = startOffset + keywordRegexp.source.length;
+        const startOffset = match.index;
+        const endOffset = startOffset + match[0].length;
         const wrapper = wrap(firstChild, startOffset, endOffset);
         wrapper.classList.add('rpv-search-text-highlight');
     };


### PR DESCRIPTION
This allows for more complex regexes and therefore the ability to have multiple keywords with a regex like `/\bsomething|other\b/i` whereas before it was using the length of the regex to wrap the proper amount of text which would be wrong for anything other than just the word.