### PR TITLE
feat(core): Support loading PDF from a protected resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 ## v2.2.0 (not released yet)
 
 **New features**
+- Support loading PDF from a protected resource with new `authorization` option.
+
+~~~ javascript
+import { Viewer } from '@react-pdf-viewer/core';
+
+<Viewer
+    fileUrl={...}
+    authorization='Bearer ...'
+/>
+~~~
+
+If you want to use another authorization servers or send more additional authentication headers, then use the new `httpHeaders` option, for example:
+
+~~~ javascript
+import { Viewer } from '@react-pdf-viewer/core';
+
+<Viewer
+    fileUrl={...}
+    httpHeaders={
+        Authorization: '...',
+    }
+/>
+~~~
+
 - It's possible to customize the search control with the new `Search` component:
 
 ~~~ javascript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ import { Viewer } from '@react-pdf-viewer/core';
 
 <Viewer
     fileUrl={...}
-    httpHeaders={
-        Authorization: '...',
-    }
+    authorization='...'
+    httpHeaders={{
+        key: value,
+    }}
 />
 ~~~
 

--- a/packages/core/src/Viewer.tsx
+++ b/packages/core/src/Viewer.tsx
@@ -56,7 +56,7 @@ export interface ViewerProps {
     defaultScale?: number | SpecialZoomLevel;
     fileUrl: string | Uint8Array;
     // Additional authentication headers
-    httpHeaders?: object;
+    httpHeaders?: Record<string, string | string[]>;
     // The page (zero-index based) that will be displayed initially
     initialPage?: number;
     // Plugins

--- a/packages/core/src/Viewer.tsx
+++ b/packages/core/src/Viewer.tsx
@@ -45,11 +45,18 @@ export interface CharacterMap {
 }
 
 export interface ViewerProps {
+    // If you want to use an authorization header to access a PDF document from a protected server, then you can use
+    // `authorization: TOKEN_HERE`, for example:
+    // `authorization: 'Bearer ...'`
+    // Use `httpHeaders` option if you want to use other authorization server
+    authorization?: string;
     characterMap?: CharacterMap;
     // The default zoom level
     // If it's not set, the initial zoom level will be calculated based on the dimesion of page and the container width
     defaultScale?: number | SpecialZoomLevel;
     fileUrl: string | Uint8Array;
+    // Additional authentication headers
+    httpHeaders?: object;
     // The page (zero-index based) that will be displayed initially
     initialPage?: number;
     // Plugins
@@ -69,9 +76,11 @@ export interface ViewerProps {
 }
 
 const Viewer: React.FC<ViewerProps> = ({
+    authorization = '',
     characterMap,
     defaultScale,
     fileUrl,
+    httpHeaders,
     initialPage = 0,
     localization,
     plugins = [],
@@ -108,8 +117,10 @@ const Viewer: React.FC<ViewerProps> = ({
             <LocalizationProvider localization={localization}>
                 {(_) => ( // eslint-disable-line @typescript-eslint/no-unused-vars
                     <DocumentLoader
+                        authorization={authorization}
                         characterMap={characterMap}
                         file={file.data}
+                        httpHeaders={httpHeaders}
                         render={(doc: PdfJs.PdfDocument) => (
                             <PageSizeCalculator
                                 doc={doc}

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -521,12 +521,19 @@ export interface CharacterMap {
 }
 
 export interface ViewerProps {
+    // If you want to use an authorization header to access a PDF document from a protected server, then you can use
+    // `authorization: TOKEN_HERE`, for example:
+    // `authorization: 'Bearer ...'`
+    // Use `httpHeaders` option if you want to use other authorization server
+    authorization?: string;
     characterMap?: CharacterMap;
     // The default zoom level
     // If it's not set, the initial zoom level will be calculated based on the dimesion of page and the container width
     // So that, the document will fit best within the container
     defaultScale?: number | SpecialZoomLevel;
     fileUrl: string | Uint8Array;
+    // Additional authentication headers
+    httpHeaders?: object;
     // The page (zero-index based) that will be displayed initially
     initialPage?: number;
     // Plugins

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -533,7 +533,7 @@ export interface ViewerProps {
     defaultScale?: number | SpecialZoomLevel;
     fileUrl: string | Uint8Array;
     // Additional authentication headers
-    httpHeaders?: object;
+    httpHeaders?: Record<string, string | string[]>;
     // The page (zero-index based) that will be displayed initially
     initialPage?: number;
     // Plugins

--- a/packages/core/src/loader/DocumentLoader.tsx
+++ b/packages/core/src/loader/DocumentLoader.tsx
@@ -25,14 +25,16 @@ import WrongPasswordState from './WrongPasswordState';
 export type RenderError = (error: LoadError) => ReactElement;
 
 interface DocumentLoaderProps {
+    authorization: string;
     characterMap?: CharacterMap;
     file: PdfJs.FileData;
+    httpHeaders?: object;
     renderError?: RenderError;
     renderLoader?(percentages: number): ReactElement;
     render(doc: PdfJs.PdfDocument): ReactElement;
 }
 
-const DocumentLoader: React.FC<DocumentLoaderProps> = ({ characterMap, file, render, renderError, renderLoader }) => {
+const DocumentLoader: React.FC<DocumentLoaderProps> = ({ authorization, characterMap, file, httpHeaders, render, renderError, renderLoader }) => {
     const theme = useContext(ThemeContext);
     const [status, setStatus] = useState<LoadingStatus>(new LoadingState(0));
 
@@ -48,11 +50,25 @@ const DocumentLoader: React.FC<DocumentLoaderProps> = ({ characterMap, file, ren
         //  This may be caused by an accidental early return statement
         //  ```
         setStatus(new LoadingState(0));
-        const params = Object.assign(
+        let params: PdfJs.GetDocumentParams = Object.assign(
             {},
             ('string' === typeof file) ? { url: file } : { data: file },
             characterMap ? { cMapUrl: characterMap.url, cMapPacked: characterMap.isCompressed } : {}
         );
+
+        if (authorization) {
+            params.withCredentials = true;
+            if (httpHeaders) {
+                params.httpHeaders = httpHeaders;
+                if (!params.httpHeaders['Authorization']) {
+                    params.httpHeaders['Authorization'] = authorization;
+                }
+            } else {
+                params.httpHeaders = {
+                    'Authorization': authorization,
+                };
+            }
+        }
 
         const loadingTask = PdfJs.getDocument(params);
         loadingTask.onPassword = (verifyPassword: VerifyPassword, reason: string): void => {

--- a/packages/core/src/loader/DocumentLoader.tsx
+++ b/packages/core/src/loader/DocumentLoader.tsx
@@ -28,7 +28,7 @@ interface DocumentLoaderProps {
     authorization: string;
     characterMap?: CharacterMap;
     file: PdfJs.FileData;
-    httpHeaders?: object;
+    httpHeaders?: Record<string, string | string[]>;
     renderError?: RenderError;
     renderLoader?(percentages: number): ReactElement;
     render(doc: PdfJs.PdfDocument): ReactElement;
@@ -50,7 +50,7 @@ const DocumentLoader: React.FC<DocumentLoaderProps> = ({ authorization, characte
         //  This may be caused by an accidental early return statement
         //  ```
         setStatus(new LoadingState(0));
-        let params: PdfJs.GetDocumentParams = Object.assign(
+        const params: PdfJs.GetDocumentParams = Object.assign(
             {},
             ('string' === typeof file) ? { url: file } : { data: file },
             characterMap ? { cMapUrl: characterMap.url, cMapPacked: characterMap.isCompressed } : {}

--- a/packages/core/src/vendors/PdfJs.d.ts
+++ b/packages/core/src/vendors/PdfJs.d.ts
@@ -48,7 +48,9 @@ declare module 'pdfjs-dist' {
         data?: FileData;
         cMapUrl?: string;
         cMapPacked?: boolean;
+        httpHeaders?: object;
         url?: string;
+        withCredentials?: boolean;
     }
     function getDocument(params: GetDocumentParams): LoadingTask;
 

--- a/packages/core/src/vendors/PdfJs.d.ts
+++ b/packages/core/src/vendors/PdfJs.d.ts
@@ -48,7 +48,7 @@ declare module 'pdfjs-dist' {
         data?: FileData;
         cMapUrl?: string;
         cMapPacked?: boolean;
-        httpHeaders?: object;
+        httpHeaders?: Record<string, string | string[]>;
         url?: string;
         withCredentials?: boolean;
     }


### PR DESCRIPTION
for #203

~~~ javascript
import { Viewer } from '@react-pdf-viewer/core';

<Viewer
    fileUrl={...}
    authorization='test'
    httpHeaders={{
        key1: 'value1',
        key2: 'value2',
    }}
/>
~~~

<img width="852" alt="Screen Shot 2020-10-31 at 22 24 47" src="https://user-images.githubusercontent.com/57786711/97783135-49c52c80-1bc8-11eb-8229-47017c0b1192.png">
