### PR TITLE
feat(core): Keep the current page and scroll position after zooming the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v2.3.0 [WIP]
+
+**Improvements**
+- Keep the current page and scroll position after zooming the document
+
 ## v2.2.0
 
 **New features**

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -135,15 +135,15 @@ const App = () => {
     );
 
     const defaultLayoutPluginInstance = defaultLayoutPlugin({
-        renderToolbar,
-        toolbarPlugin: {
-            scrollModePlugin: {
-                scrollMode: ScrollMode.Vertical,
-            },
-            searchPlugin: {
-                keyword: ['document', 'PDF'],
-            },
-        },
+        // renderToolbar,
+        // toolbarPlugin: {
+        //     scrollModePlugin: {
+        //         scrollMode: ScrollMode.Vertical,
+        //     },
+        //     searchPlugin: {
+        //         keyword: ['document', 'PDF'],
+        //     },
+        // },
     });
 
     return (

--- a/packages/core/src/layouts/Inner.tsx
+++ b/packages/core/src/layouts/Inner.tsx
@@ -153,7 +153,8 @@ const Inner: React.FC<InnerProps> = ({
 
     const zoom = (newScale: number | SpecialZoomLevel): void => {
         const pagesEle = pagesRef.current;
-        if (!pagesEle) {
+        const currentState = stateRef.current;
+        if (!pagesEle || !currentState) {
             return;
         }
 
@@ -178,17 +179,32 @@ const Inner: React.FC<InnerProps> = ({
                 updateScale = newScale;
                 break;
         }
+
         setScale(updateScale);
         onZoom({ doc, scale: updateScale });
+    };
+
+    useEffect(() => {
+        const pagesEle = pagesRef.current;
+        const currentState = stateRef.current;
+        if (!pagesEle || !currentState) {
+            return;
+        }
+
+        // Keep the current scroll position
+        pagesEle.scrollTop = pagesEle.scrollTop * scale / currentState.scale;
+        pagesEle.scrollLeft = pagesEle.scrollLeft * scale / currentState.scale;
+        
         setViewerState({
             file: viewerState.file,
-            pageIndex: currentPage,
+            // Keep the current page after zooming
+            pageIndex: currentState.pageIndex,
             pageHeight,
             pageWidth,
             rotation,
-            scale: updateScale,
+            scale: scale,
         });
-    };
+    }, [scale]);
 
     // Important rule: All the plugin methods can't use the internal state (`currentPage`, `rotation`, `scale`, for example).
     // These methods when being called from plugins will use the initial value of state, not the latest one.


### PR DESCRIPTION
for #346 

![zoom](https://user-images.githubusercontent.com/57786711/98822885-f4104000-2463-11eb-9406-0d77f17eebbd.gif)
