### PR TITLE
Invalid option for Mini CSS Extract Plugin in Demo Code

### DIFF
--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -16,9 +16,7 @@ module.exports = {
                 use: [
                     {
                         loader: MiniCssExtractPlugin.loader,
-                        options: {
-                            hmr: process.env.NODE_ENV === 'development',
-                        },
+                        options: {},
                     },
                     'css-loader',
                 ],


### PR DESCRIPTION
Issue: https://github.com/react-pdf-viewer/react-pdf-viewer/issues/363