### PR TITLE
fix(default-layout): Can't scroll between pages on Safari 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v2.4.1 [WIP]
 
 **Bug fixes**
-- Clicking the Download button doesn't work. It only works the file when scrolling to the second page.
+- Clicking the Download button doesn't work. It only works the file when scrolling to the second page
+- Using the Default Layout plugin, we can't scroll between pages on Safari 14
 
 ## v2.4.0
 

--- a/packages/default-layout/src/styles/defaultLayout.less
+++ b/packages/default-layout/src/styles/defaultLayout.less
@@ -32,6 +32,8 @@
 .rpv-default-layout-main {
     display: flex;
     flex-grow: 1;
+    /* Fix the scroll issue on Safari */
+    height: 100%;
     overflow: hidden;
 }
 


### PR DESCRIPTION
for #474 