### PR TITLE
fix(core): Clicking on an internal link jumps to an incorrect page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v2.4.3 [WIP]
 
+**Bug fixes**
+- Clicking on an internal link jumps to an incorrect page (one page after the destination one)
+
 **Improvements**
 - Automatically scroll to the thumbnail that represents the current page
 - Display the progress properly when printing a big document

--- a/packages/core/src/annotations/Link.tsx
+++ b/packages/core/src/annotations/Link.tsx
@@ -31,7 +31,7 @@ const Link: React.FC<LinkProps> = ({ annotation, doc, page, viewport, onExecuteN
             ? onExecuteNamedAction(annotation.action)
             : getDestination(doc, annotation.dest).then((target) => {
                 const { pageIndex, bottomOffset, scaleTo } = target;
-                onJumpToDest(pageIndex + 1, bottomOffset, 0, scaleTo);
+                onJumpToDest(pageIndex, bottomOffset, 0, scaleTo);
             });
     };
 


### PR DESCRIPTION
for #516 