### PR TITLE
feat(toolbar): Adjust the default toolbar in different screen sizes

### DIFF
--- a/packages/core/src/styles/index.less
+++ b/packages/core/src/styles/index.less
@@ -31,3 +31,4 @@
 @import './spinner.less';
 @import './textLayer.less';
 @import './tooltipBody.less';
+@import './utils.less';

--- a/packages/core/src/styles/utils.less
+++ b/packages/core/src/styles/utils.less
@@ -1,0 +1,31 @@
+/**
+ * A React component to view a PDF document
+ *
+ * @see https://react-pdf-viewer.dev
+ * @license https://react-pdf-viewer.dev/license
+ * @copyright 2019-2021 Nguyen Huu Phuoc <me@phuoc.ng>
+ */
+
+.rpv-core-display-block {
+    display: block;
+}
+.rpv-core-display-hidden {
+    display: none;
+}
+
+@media (min-width: 768px) {
+    .rpv-core-display-hidden-medium {
+        display: none;
+    }
+    .rpv-core-display-block-medium {
+        display: block;
+    }
+}
+@media (min-width: 1024px) {
+    .rpv-core-display-hidden-large {
+        display: none;
+    }
+    .rpv-core-display-block-large {
+        display: block;
+    }
+}

--- a/packages/toolbar/src/MoreActionsPopover.tsx
+++ b/packages/toolbar/src/MoreActionsPopover.tsx
@@ -23,7 +23,7 @@ const PORTAL_OFFSET = { left: 0, top: 8 };
 const MoreActionsPopover: React.FC<MoreActionsPopoverProps> = ({ toolbarSlot }) => {
     const l10n = React.useContext(LocalizationContext);
     const {
-        GoToFirstPageMenuItem, GoToLastPageMenuItem, RotateBackwardMenuItem, RotateForwardMenuItem, ShowPropertiesMenuItem,
+        DownloadMenuItem, EnterFullScreenMenuItem, GoToFirstPageMenuItem, GoToLastPageMenuItem, GoToNextPageMenuItem, GoToPreviousPageMenuItem, OpenMenuItem, PrintMenuItem, RotateBackwardMenuItem, RotateForwardMenuItem, ShowPropertiesMenuItem,
         SwitchScrollModeMenuItem, SwitchSelectionModeMenuItem,
     } = toolbarSlot;
 
@@ -43,7 +43,30 @@ const MoreActionsPopover: React.FC<MoreActionsPopoverProps> = ({ toolbarSlot }) 
     const renderContent = (toggle: Toggle): React.ReactElement => {
         return (
             <Menu>
+                {/* These items will be hidden on the larger screens */}
+                <div className="rpv-core-display-block rpv-core-display-hidden-medium">
+                    <EnterFullScreenMenuItem onClick={toggle} />
+                </div>
+                <div className="rpv-core-display-block rpv-core-display-hidden-medium">
+                    <OpenMenuItem />
+                </div>
+                <div className="rpv-core-display-block rpv-core-display-hidden-medium">
+                    <PrintMenuItem onClick={toggle} />
+                </div>
+                <div className="rpv-core-display-block rpv-core-display-hidden-medium">
+                    <DownloadMenuItem onClick={toggle} />
+                </div>
+                <div className="rpv-core-display-block rpv-core-display-hidden-medium">
+                    <MenuDivider />
+                </div>
+
                 <GoToFirstPageMenuItem onClick={toggle} />
+                <div className="rpv-core-display-block rpv-core-display-hidden-medium">
+                    <GoToPreviousPageMenuItem onClick={toggle} />
+                </div>
+                <div className="rpv-core-display-block rpv-core-display-hidden-medium">
+                    <GoToNextPageMenuItem onClick={toggle} />
+                </div>
                 <GoToLastPageMenuItem onClick={toggle} />
                 <MenuDivider />
                 <RotateForwardMenuItem onClick={toggle} />

--- a/packages/toolbar/src/defaultToolbar.tsx
+++ b/packages/toolbar/src/defaultToolbar.tsx
@@ -24,39 +24,53 @@ const defaultToolbar = (toolbarSlot: ToolbarSlot): React.ReactElement => {
                 <div className='rpv-toolbar-item'>
                     <ShowSearchPopover />
                 </div>
-                <div className='rpv-toolbar-item'>
-                    <GoToPreviousPage />
+                <div className="rpv-core-display-hidden rpv-core-display-block-medium">
+                    <div className='rpv-toolbar-item'>
+                        <GoToPreviousPage />
+                    </div>
                 </div>
                 <div className='rpv-toolbar-item'>
                     <CurrentPageInput /> / <NumberOfPages />
                 </div>
-                <div className='rpv-toolbar-item'>
-                    <GoToNextPage />
+                <div className="rpv-core-display-hidden rpv-core-display-block-medium">
+                    <div className='rpv-toolbar-item'>
+                        <GoToNextPage />
+                    </div>
                 </div>
             </div>
             <div className='rpv-toolbar-center'>
                 <div className='rpv-toolbar-item'>
                     <ZoomOut />
                 </div>
-                <div className='rpv-toolbar-item'>
-                    <Zoom />
+                <div className="rpv-core-display-hidden rpv-core-display-block-medium">
+                    <div className='rpv-toolbar-item'>
+                        <Zoom />
+                    </div>
                 </div>
                 <div className='rpv-toolbar-item'>
                     <ZoomIn />
                 </div>
             </div>
             <div className='rpv-toolbar-right'>
-                <div className='rpv-toolbar-item'>
-                    <EnterFullScreen />
+                <div className="rpv-core-display-hidden rpv-core-display-block-medium">
+                    <div className='rpv-toolbar-item'>
+                        <EnterFullScreen />
+                    </div>
                 </div>
-                <div className='rpv-toolbar-item'>
-                    <Open />
+                <div className="rpv-core-display-hidden rpv-core-display-block-medium">
+                    <div className='rpv-toolbar-item'>
+                        <Open />
+                    </div>
                 </div>
-                <div className='rpv-toolbar-item'>
-                    <Download />
+                <div className="rpv-core-display-hidden rpv-core-display-block-medium">
+                    <div className='rpv-toolbar-item'>
+                        <Download />
+                    </div>
                 </div>
-                <div className='rpv-toolbar-item'>
-                    <Print />
+                <div className="rpv-core-display-hidden rpv-core-display-block-medium">
+                    <div className='rpv-toolbar-item'>
+                        <Print />
+                    </div>
                 </div>
                 <div className='rpv-toolbar-item'>
                     <MoreActionsPopover toolbarSlot={toolbarSlot} />


### PR DESCRIPTION
for #385 

_Mobile phone_
<img width="405" alt="Screen Shot 2021-05-15 at 16 55 20" src="https://user-images.githubusercontent.com/57786711/118356250-74903480-b59e-11eb-8d12-5775aa244663.png">

_Tablet_
<img width="809" alt="Screen Shot 2021-05-15 at 16 55 08" src="https://user-images.githubusercontent.com/57786711/118356258-807bf680-b59e-11eb-8b45-82033eb356ee.png">
