### PR TITLE
fix(thumbnails): There are big spaces between thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These components are available as [Toolbar slots](https://react-pdf-viewer.dev/p
 - The icons use the current color instead of hard coded one. It's more easy for us to create themes.
 
 **Bug fix**
+- There are big spaces between thumbnails
 - Zoom the document best inside the container initially
 
 **Breaking changes**

--- a/packages/thumbnail/src/styles/thumbnailContainer.less
+++ b/packages/thumbnail/src/styles/thumbnailContainer.less
@@ -8,7 +8,7 @@
 
 .rpv-thumbnail-container {
     align-items: center;
-    box-shadow: rgba(0, 0, 0, 0.2) 2px 2px 8px 0px;
+    box-shadow: rgba(0, 0, 0, .2) 2px 2px 8px 0px;
     display: flex;
     justify-content: center;
     margin: 0px auto;

--- a/packages/thumbnail/src/styles/thumbnailList.less
+++ b/packages/thumbnail/src/styles/thumbnailList.less
@@ -8,7 +8,7 @@
 
 .rpv-thumbnail-item {
     cursor: pointer;
-    padding: 0.5rem;
+    padding: .5rem;
 }
 
 .rpv-thumbnail-item:hover,
@@ -17,6 +17,8 @@
 }
 
 .rpv-thumbnail-list {
+    align-content: flex-start;
+    align-items: center;
     display: flex;
     height: 100%;
     flex-flow: row wrap;


### PR DESCRIPTION
fix #557 

<img width="373" alt="Screen Shot 2021-05-18 at 20 34 21" src="https://user-images.githubusercontent.com/57786711/118660495-72d1a580-b818-11eb-8d29-4249119c4805.png">
