### PR TITLE
fix(core): The initialPage and defaultScale options don't work together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ These components are available as [Toolbar slots](https://react-pdf-viewer.dev/p
 - The icons use the current color instead of hard coded one. It's more easy for us to create themes.
 
 **Bug fixes**
+- The `initialPage` and `defaultScale` options don't work together
 - There are big spaces between thumbnails
 - Zoom the document best inside the container initially
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -20,7 +20,7 @@ const App = () => {
                 <Viewer
                     fileUrl='pdf-open-parameters.pdf'
                     initialPage={3}
-                    defaultScale={1.2}
+                    // defaultScale={1.2}
                     plugins={[
                         defaultLayoutPluginInstance,
                     ]}

--- a/packages/core/src/Viewer.tsx
+++ b/packages/core/src/Viewer.tsx
@@ -155,7 +155,6 @@ const Viewer: React.FC<ViewerProps> = ({
                                         doc={doc}
                                         render={(ps: PageSize) => (
                                             <Inner
-                                                defaultScale={defaultScale}
                                                 doc={doc}
                                                 initialPage={initialPage}
                                                 pageSize={ps}

--- a/packages/core/src/layouts/Inner.tsx
+++ b/packages/core/src/layouts/Inner.tsx
@@ -26,7 +26,6 @@ const SCROLL_BAR_WIDTH = 17;
 const PAGE_PADDING = 8;
 
 interface InnerProps {
-    defaultScale?: number | SpecialZoomLevel;
     doc: PdfJs.PdfDocument;
     initialPage?: number;
     pageSize: PageSize;
@@ -40,7 +39,7 @@ interface InnerProps {
 }
 
 const Inner: React.FC<InnerProps> = ({
-    defaultScale, doc, initialPage, pageSize, plugins, renderPage, viewerState,
+    doc, initialPage, pageSize, plugins, renderPage, viewerState,
     onDocumentLoad, onOpenFile, onPageChange, onZoom,
 }) => {
     const theme = React.useContext(ThemeContext);
@@ -254,13 +253,6 @@ const Inner: React.FC<InnerProps> = ({
             scale,
         });
     }, [currentPage]);
-
-    React.useEffect(() => {
-        // If the default scale is set
-        if (defaultScale) {
-            zoom(defaultScale);
-        }
-    }, []);
 
     const pageVisibilityChanged = (pageIndex: number, ratio: number): void => {
         pageVisibility[pageIndex] = ratio;

--- a/packages/core/src/layouts/PageSizeCalculator.tsx
+++ b/packages/core/src/layouts/PageSizeCalculator.tsx
@@ -40,15 +40,14 @@ const PageSizeCalculator: React.FC<PageSizeCalculatorProps> = ({ defaultScale, d
             const pagesEle = pagesRef.current;
             if (!pagesEle) {
                 return;
-            }
-            
+            }            
 
             // Determine the best scale that fits the document within the container
             // We spend 50 pixels in the left and right sides for other parts such as sidebar
             const scaled = (pagesEle.clientWidth - 2 * 50) / w;
             
-            let scale = typeof defaultScale === 'string'
-                        ? calculateScale(pagesEle, h, w, defaultScale)
+            let scale = defaultScale
+                        ? (typeof defaultScale === 'string' ? calculateScale(pagesEle, h, w, defaultScale) : defaultScale)
                         : decrease(scaled);
 
             setPageSize({


### PR DESCRIPTION
for #164 
for #489 

_Demo_

```js
<Viewer
    fileUrl='...'
    initialPage={3}
    defaultScale={0.5}
/>
```

<img width="1056" alt="Screen Shot 2021-05-18 at 22 21 32" src="https://user-images.githubusercontent.com/57786711/118679170-db744e80-b827-11eb-9add-878a28955521.png">

```js
<Viewer
    fileUrl='...'
    initialPage={3}
    defaultScale={1.0}
/>
```

<img width="1062" alt="Screen Shot 2021-05-18 at 22 21 47" src="https://user-images.githubusercontent.com/57786711/118679275-f34bd280-b827-11eb-9575-b62a758d67ca.png">

```js
<Viewer
    fileUrl='...'
    initialPage={3}
    defaultScale={2.0}
/>
```

<img width="1052" alt="Screen Shot 2021-05-18 at 22 22 01" src="https://user-images.githubusercontent.com/57786711/118679352-065ea280-b828-11eb-81c4-7320ea4b8fd5.png">

```js
<Viewer
    fileUrl='...'
    initialPage={3}
    defaultScale={SpecialZoomLevel.PageFit}
/>
```

<img width="1048" alt="Screen Shot 2021-05-18 at 22 22 21" src="https://user-images.githubusercontent.com/57786711/118679433-15455500-b828-11eb-9f0a-3607c8083015.png">
