### PR TITLE
fix(core): Fix warning when pressing Esc key to close a modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ Continue improving the accessibility:
 | `Menu`    | `End`     | Focus on the last menu item  |
 |           | `Home`    | Focus on the first menu item |
 
-**Bug fix**
+**Bug fixes**
 
 -   Automatically scroll to the top of page when opening a menu
+-   Fix the warning when pressing the _Escape_ key to close a modal
 
 ## v2.7.0
 

--- a/packages/core/src/portal/ModalBody.tsx
+++ b/packages/core/src/portal/ModalBody.tsx
@@ -22,7 +22,11 @@ export const ModalBody: React.FC<{
     const contentRef = React.useRef<HTMLDivElement>();
 
     useLockScroll();
-    useEscape(() => closeOnEscape && onToggle());
+    useEscape(() => {
+        if (contentRef.current && closeOnEscape) {
+            onToggle();
+        }
+    });
     useClickOutside(closeOnClickOutside, contentRef, onToggle);
 
     useIsomorphicLayoutEffect(() => {

--- a/packages/core/src/portal/PopoverOverlay.tsx
+++ b/packages/core/src/portal/PopoverOverlay.tsx
@@ -14,7 +14,12 @@ export const PopoverOverlay: React.FC<{
     closeOnEscape: boolean;
     onClose(): void;
 }> = ({ closeOnEscape, onClose }) => {
-    useEscape(() => closeOnEscape && onClose());
+    const containerRef = React.useRef<HTMLDivElement>();
+    useEscape(() => {
+        if (containerRef.current && closeOnEscape) {
+            onClose();
+        }
+    });
 
-    return <div className="rpv-core__popover-overlay" />;
+    return <div className="rpv-core__popover-overlay" ref={containerRef} />;
 };


### PR DESCRIPTION
fix #693 