### PR TITLE
fix: The search highlight elements should be shown below the text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ import { TextDirection, Viewer } from '@react-pdf-viewer/core';
 
 -   The `RenderViewer` type includes the theme context
 
-**Bug fix**
+**Bug fixes**
 
+-   The highlighting elements should be shown below the text, so users can still select the text
 -   There is an exception when opening a password protected document
 
 ## v2.7.2

--- a/packages/search/src/Tracker.tsx
+++ b/packages/search/src/Tracker.tsx
@@ -90,7 +90,7 @@ export const Tracker: React.FC<{
         const containerRect = containerEle.getBoundingClientRect();
 
         const highlightEle = document.createElement('span');
-        containerEle.appendChild(highlightEle);
+        containerEle.insertBefore(highlightEle, containerEle.firstChild);
 
         highlightEle.style.left = `${(100 * (wrapperRect.left - containerRect.left)) / containerRect.width}%`;
         highlightEle.style.top = `${(100 * (wrapperRect.top - containerRect.top)) / containerRect.height}%`;


### PR DESCRIPTION
for #738 