### PR TITLE
fix: Don't highlight the entire page when selecting multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ const defaultLayoutPluginInstance = defaultLayoutPlugin({
 
 **Bug fixes**
 
+-   Don't highlight the entire page when selecting multiple lines
 -   The highlight plugin throws an exception when double click a page without selecting any text
 -   The default layout plugin throws an exception if the `setInitialTabFromPageMode` function returns a `Promise` which resolves an invalid tab index
 

--- a/packages/core/src/styles/textLayer.scss
+++ b/packages/core/src/styles/textLayer.scss
@@ -25,11 +25,15 @@
     // Make it displayed on top of the shadow layer
     // so users can select text of pages
     z-index: 1;
-}
 
-.rpv-core__text-layer ::selection {
-    background-color: var(--rpv-core__text-layer-text--selection-background-color);
-    color: var(--rpv-core__text-layer-text--selection-color);
+    span::selection {
+        background-color: var(--rpv-core__text-layer-text--selection-background-color);
+        color: var(--rpv-core__text-layer-text--selection-color);
+    }
+
+    br::selection {
+        color: transparent;
+    }
 }
 
 .rpv-core__text-layer-text {


### PR DESCRIPTION
#1103 