### PR TITLE
fix: Can't search or set the initial keyword for scanned documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@ const printPluginInstance = printPlugin({
 });
 ```
 
+**Bug fix**
+
+-   Can't search or set the initial keyword for scanned documents
+
 ## v3.5.0
 
 **New feature**

--- a/packages/search/src/Highlights.tsx
+++ b/packages/search/src/Highlights.tsx
@@ -155,7 +155,7 @@ export const Highlights: React.FC<{
     const highlightAll = (textLayerEle: Element): HighlightArea[] => {
         const charIndexes = characterIndexesRef.current;
         if (charIndexes.length === 0) {
-            return;
+            return [];
         }
 
         const highlightPos: HighlightArea[] = [];


### PR DESCRIPTION
for #1184 