### PR TITLE
fix: Link annotations with unsafe URLs won't be rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ const defaultLayoutPluginInstance = defaultLayoutPlugin({
 **Bug fixes**
 
 -   Clicking a particular bookmark might not go to the destination
+-   Link annotations with unsafe URLs won't be rendered to avoid secutiry issues
 -   The `CharacterMap` type isn't available
 -   The page navigation options are missing when creating a toolbar plugin
 -   The search popover always shows up after pressing shortcuts

--- a/packages/core/src/annotations/Link.tsx
+++ b/packages/core/src/annotations/Link.tsx
@@ -30,15 +30,14 @@ export const Link: React.FC<{
               });
     };
 
-    const isRenderable = !!(annotation.url || annotation.dest || annotation.action || annotation.unsafeUrl);
-    const externalUrl = annotation.url || annotation.unsafeUrl;
-    const attrs = externalUrl
+    const isRenderable = !!(annotation.url || annotation.dest || annotation.action);
+    const attrs = annotation.url
         ? {
               'data-target': 'external',
-              href: externalUrl,
+              href: annotation.url,
               rel: 'noopener noreferrer nofollow',
               target: annotation.newWindow ? '_blank' : '',
-              title: externalUrl,
+              title: annotation.url,
           }
         : {
               href: '',


### PR DESCRIPTION
#1214 