### PR TITLE
Fixed issue of selectedText for highlight not matching the actual hig…

### DIFF
--- a/packages/highlight/src/getTextFromOffsets.ts
+++ b/packages/highlight/src/getTextFromOffsets.ts
@@ -14,25 +14,15 @@ export const getTextFromOffsets = (
     endOffset?: number
 ): string => {
     const nodes: Node[] = [].slice.call(textLayerDiv.children);
-
-    if (startDivIdx < endDivIdx) {
-        const startDivText = nodes
-            .slice(startDivIdx, startDivIdx + 1)
-            .map((node) => node.textContent.substring(startOffset).trim())
-            .join(' ');
-
-        const middleDivText = nodes
-            .slice(startDivIdx + 1, endDivIdx)
-            .map((node) => node.textContent.trim())
-            .join(' ');
-
-        const endDivText = nodes
-            .slice(endDivIdx, endDivIdx + 1)
-            .map((endDiv) => endDiv.textContent.substring(0, endOffset || endDiv.textContent.length))
-            .join(' ');
-        return `${startDivText} ${middleDivText} ${endDivText}`;
-    } else {
-        const div = nodes[startDivIdx];
-        return div.textContent.substring(startOffset, endOffset || div.textContent.length).trim();
-    }
+    // need to include extra end node if the last node is a <br/> node without any text
+    const extraEndNode = (nodes.length > endDivIdx + 1 && nodes[endDivIdx].nodeName == "BR");
+    const selectedNodes = nodes.slice(startDivIdx, extraEndNode ? endDivIdx + 2 : endDivIdx + 1);
+    const nodesText = selectedNodes
+        .map((node) => node.textContent)
+        .filter((text) => !!text)   // filter out nodes with no text (e.g. <br/> nodes)
+        .join(' ');
+        
+    const offsetFromEnd = endOffset ? selectedNodes[selectedNodes.length - 1].textContent!.length - endOffset : 0;
+    const selectText = nodesText.substring(startOffset, nodesText.length - offsetFromEnd);
+    return selectText.replace(/\s\s+/g, ' ');   // remove duplicate spaces
 };


### PR DESCRIPTION
I noticed that for some PDFs, the `selectedText` doesn't accurately match the actual highlighted text. Here is an example:
![image](https://user-images.githubusercontent.com/16188477/185509428-14ba7bff-291d-4b3c-8c5b-ac6fbba53a7c.png)

I identified this to be because for some PDF files, there are <br/> elements for every new line and those are also considered nodes. When the final highlighted node was a <br/>, the `selectedText` didn't include the last line, and similarly, when the first highlighted node was a <br/>, the entire first line was selected. 

This is my fix to this problem (it's just a one function change to `getTextFromOffsets`) - I have verified this to work with the PDFs that I have tried, but please double check if it works. I have also simplified the function by removing the if conditions for a single line selection and multiple line selection.