### PR TITLE
Prevent error from accessing property of undefined in ShortcutHandler

### DIFF
--- a/packages/page-navigation/src/ShortcutHandler.tsx
+++ b/packages/page-navigation/src/ShortcutHandler.tsx
@@ -64,10 +64,13 @@ export const ShortcutHandler: React.FC<{
 
     const handleKeydown = (e: KeyboardEvent) => {
         const containerEle = containerRef.current;
+        if (!containerEle) {
+          return;
+        }
         const shouldHandleShortcuts =
             isMouseInsideRef.current || (document.activeElement && containerEle.contains(document.activeElement));
 
-        if (!containerEle || !shouldHandleShortcuts) {
+        if (!shouldHandleShortcuts) {
             return;
         }
 


### PR DESCRIPTION
Noticed this in our application. Prevents issue with "containerEle.contains".