### PR TITLE
Fix viewer not closing full screen when in shadow dom

### DIFF
--- a/packages/core/src/fullscreen/useFullScreen.ts
+++ b/packages/core/src/fullscreen/useFullScreen.ts
@@ -78,7 +78,7 @@ export const useFullScreen = ({
         const currentFullScreenEle = getFullScreenElement();
         if (currentFullScreenEle && currentFullScreenEle !== target) {
             setFullScreenMode(FullScreenMode.Normal);
-            return exitFullScreen(currentFullScreenEle);
+            return exitFullScreen(document);
         }
 
         return Promise.resolve();


### PR DESCRIPTION
When using the viewer from within a shadow dom, full screen does not close and gives error `[Uncaught TypeError: element[vendor.ExitFullScreen] is not a function`

[The function ExitFullScreen only exists on document](https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen). In the code it was being called on the document.FullScreenElement, which normally returns document, but in the case of a shadow dom it returns the shadow root.