### PR TITLE
Insert space if there is a new line for searching

### DIFF
--- a/packages/search/src/useSearch.ts
+++ b/packages/search/src/useSearch.ts
@@ -136,7 +136,7 @@ export const useSearch = (
                         return page.getTextContent();
                     })
                     .then((content) => {
-                        const pageContent = content.items.map((item) => item.str || '').join('');
+                        const pageContent = content.items.filter((item) => item.str !== '').map((item) => item.str || '').join(' ');
                         return Promise.resolve({
                             pageContent,
                             pageIndex,


### PR DESCRIPTION
Currently search does not account for new lines properly, combining the last word of the previous line and the first word of the new line without a space between them. This allows the search to function properly. 