### PR TITLE
Fix: Sort matches by position when using multiple keywords

### DIFF
--- a/packages/search/src/useSearch.ts
+++ b/packages/search/src/useSearch.ts
@@ -219,6 +219,16 @@ export const useSearch = (
                         });
                     }
                 });
+
+                // Sort matches by page index first, then by position within the page
+                // This ensures prev/next navigation moves sequentially through the document
+                arr.sort((a, b) => {
+                    if (a.pageIndex !== b.pageIndex) {
+                        return a.pageIndex - b.pageIndex;
+                    }
+                    return a.startIndex - b.startIndex;
+                });
+
                 setFound(arr);
                 if (arr.length > 0) {
                     setCurrentMatch(1);


### PR DESCRIPTION
## Summary
Fixes erratic prev/next navigation when using multiple keywords by sorting matches by their actual position in the document.

## Problem
When `highlight()` is called with multiple keywords, the matches array was ordered by keyword rather than by position. This caused navigation to loop through all instances of keyword A, then jump back to loop through keyword B on the same page.

## Solution
Added a sort after collecting all matches that orders them by:
1. Page index (ascending)
2. Start index within the page (ascending)

## Changes
- Added `arr.sort()` in `useSearch.ts` after match collection (line 225)
- Matches are now in document order regardless of which keyword produced them

## Testing
Verified with multiple keywords that prev/next navigation now moves sequentially through the document.

## Visual Evidence
Before this fix, navigation would jump erratically:
<img width="1661" height="620" alt="image" src="https://github.com/user-attachments/assets/62e977ab-0272-42cc-a826-7929ba0664f5" />
