### PR TITLE
Fix: Prevent scrolling to page top when navigating to matches on the same page

### DIFF
--- a/packages/search/src/searchPlugin.tsx
+++ b/packages/search/src/searchPlugin.tsx
@@ -133,6 +133,7 @@ export const searchPlugin = (props?: SearchPluginProps): SearchPlugin => {
             const keyword = props && props.keyword ? normalizeKeywords(props.keyword) : [EMPTY_KEYWORD_REGEXP];
 
             store.update('initialKeyword', initialKeyword);
+            store.update('getViewerState', pluginFunctions.getViewerState);
             store.update('jumpToDestination', pluginFunctions.jumpToDestination);
             store.update('jumpToPage', pluginFunctions.jumpToPage);
             store.update('keyword', keyword);

--- a/packages/search/src/types/StoreProps.ts
+++ b/packages/search/src/types/StoreProps.ts
@@ -19,6 +19,7 @@ export interface StoreProps {
     keyword?: NormalizedKeyword[];
     matchPosition: MatchPosition;
     renderStatus: Map<number, PluginOnTextLayerRender>;
+    getViewerState?(): any;
     jumpToDestination?(destination: Destination): void;
     jumpToPage?(pageIndex: number): void;
     targetPageFilter?: SearchTargetPageFilter;

--- a/packages/search/src/useSearch.ts
+++ b/packages/search/src/useSearch.ts
@@ -150,10 +150,18 @@ export const useSearch = (
     };
 
     const jumpToGivenMatch = (match: Match): Match => {
+        const getViewerState = store.get('getViewerState');
         const jumpToPage = store.get('jumpToPage');
-        if (jumpToPage) {
-            jumpToPage(match.pageIndex);
+
+        // Only jump to page if we're navigating to a different page
+        // This prevents unnecessary scrolling when the next match is on the same page
+        if (jumpToPage && getViewerState) {
+            const currentPageIndex = getViewerState().pageIndex;
+            if (currentPageIndex !== match.pageIndex) {
+                jumpToPage(match.pageIndex);
+            }
         }
+
         store.update('matchPosition', {
             matchIndex: match.matchIndex,
             pageIndex: match.pageIndex,


### PR DESCRIPTION
## Description

When using `jumpToNextMatch()`/`jumpToPreviousMatch()`, if the next match is on the same page as the current match, the viewer would scroll to the top of the page instead of keeping the current scroll position.

## Problem

The issue occurs in the `jumpToGivenMatch` function in `useSearch.ts`. It always calls `jumpToPage(match.pageIndex)` even when the user is already on that page. This causes an unnecessary page navigation that resets the scroll position to the top of the page.

## Solution

- Store `getViewerState` function from `PluginFunctions` in the plugin store
- Before calling `jumpToPage()`, check if we're already on the target page using `getViewerState().pageIndex`
- Only call `jumpToPage()` when navigating to a different page
- Always update `matchPosition` to highlight the correct match

## Benefits

- Preserves scroll position when cycling through multiple matches on the same page
- Improves user experience during search navigation
- Reduces unnecessary DOM operations

## Testing

To reproduce the original issue:
1. Open a PDF with multiple matches on the same page
2. Use prev/next navigation to cycle through matches
3. Observer: scroll jumps to top when moving between matches on the same page

After this fix:
1. Follow the same steps
2. Observe: scroll position is preserved when matches are on the same page
3. Scroll still works correctly when navigating to matches on different pages

## Related Issues

This fix addresses the scroll-to-top issue when navigating between matches on the same page.