### PR TITLE
Fix: Only scroll to match when it's outside the viewport

### DIFF
--- a/packages/search/src/Highlights.tsx
+++ b/packages/search/src/Highlights.tsx
@@ -334,21 +334,34 @@ export const Highlights: React.FC<{
             return;
         }
 
+        // Check if the highlight is already visible in the viewport
+        const highlightRect = highlightEle.getBoundingClientRect();
+        const containerRect = container.getBoundingClientRect();
+        const isVisible =
+            highlightRect.top >= containerRect.top &&
+            highlightRect.bottom <= containerRect.bottom &&
+            highlightRect.left >= containerRect.left &&
+            highlightRect.right <= containerRect.right;
+
+        // Only scroll if the highlight is not already visible in the viewport
+        // This prevents unnecessary scrolling when navigating between matches that are already on screen
         const { left, top } = calculateOffset(highlightEle as HTMLElement, container);
         const jump = store.get('jumpToDestination');
-        if (jump) {
+        if (jump && !isVisible) {
             jump({
                 pageIndex,
                 bottomOffset: (container.getBoundingClientRect().height - top) / renderStatus.scale,
                 leftOffset: left / renderStatus.scale,
                 scaleTo: renderStatus.scale,
             });
-            if (currentMatchRef.current) {
-                currentMatchRef.current.classList.remove(styles.highlightCurrent);
-            }
-            currentMatchRef.current = highlightEle as HTMLElement;
-            highlightEle.classList.add(styles.highlightCurrent);
         }
+
+        // Always update the current highlight styling
+        if (currentMatchRef.current) {
+            currentMatchRef.current.classList.remove(styles.highlightCurrent);
+        }
+        currentMatchRef.current = highlightEle as HTMLElement;
+        highlightEle.classList.add(styles.highlightCurrent);
     }, [highlightAreas, matchPosition]);
 
     React.useEffect(() => {


### PR DESCRIPTION
## Problem

When using `jumpToNextMatch()`/`jumpToPreviousMatch()`, the viewer would always scroll to the match position, even when the match was already fully visible in the viewport. This caused disruptive scrolling behavior when cycling through multiple matches that were visible on the same screen.

### Reproduction

1. Search for a term that has multiple matches on the same visible area
2. Use prev/next navigation to cycle through matches
3. Observer: The page scrolls/jumps even when all matches are already visible

## Solution

Check if the highlight element is already visible in the viewport before scrolling:
- Use `getBoundingClientRect()` to compare the highlight position with the container viewport
- Only call `jumpToDestination()` when the highlight is outside the visible area
- Always update the highlight styling (current match indicator) regardless of visibility

## Benefits

- **Smoother navigation**: Users can cycle through visible matches without unwanted page jumps
- **Better UX**: Scrolling only happens when necessary (match is off-screen)
- **Preserves existing behavior**: Still scrolls when needed to bring off-screen matches into view

## Testing

Before this fix:
1. Search for a common term with multiple matches on one screen
2. Use next/prev buttons
3. Page scrolls on every navigation even when matches are visible

After this fix:
1. Follow same steps
2. Page only scrolls when navigating to off-screen matches
3. Visible matches can be cycled through smoothly without scrolling